### PR TITLE
Moved OAuth-authentication into library and upgraded restler to new version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *~
 .DS_Store
-
+node_modules
 restler

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Full documentation is available with `./23video --help`:
     -h, --help                            output usage information
     -V, --version                         output the version number
     -m, --method <method>                 Method to call in the 23 Video API
-    -d, --domain [domain]                 Domain for the 23 Video site
+    -h, --hostname [hostname]             Domain for the 23 Video site
     -a, --auth                            Authenticate against the 23 Video API
     -k, --key [key]                       OAuth consumer key
     -s, --secret [secret]                 OAuth consumer secret

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -23,11 +23,12 @@ function getNonce(len) {
 // Utility: URL encoding is slightly complex in the OAuth spec
 function uriEncode(s) {
   var s= encodeURIComponent(s);
-  return s.replace(/\!/g, "%21")
+  s = s.replace(/\!/g, "%21")
           .replace(/\'/g, "%27")
           .replace(/\(/g, "%28")
           .replace(/\)/g, "%29")
           .replace(/\*/g, "%2A");
+  return s;
 }
 
 // Utility: Mix content of one object into another (1:1 dublicate from restler.js; can be eliminated)
@@ -79,7 +80,6 @@ exports.signature = function(url, options){
 
   // 3. Create a base string for signatures
   var signatureBaseString = [options.method.toUpperCase(), uriEncode(normalizedURL), uriEncode(normalizedParams)].join('&');
-  //console.log(signatureBaseString);
 
   // 4. And actually sign the string
   var signatureSecret = [uriEncode(options.oauthConsumerSecret||''), uriEncode(options.oauthAccessTokenSecret||'')].join('&');
@@ -100,7 +100,6 @@ exports.signature = function(url, options){
   normalizedHeaderParts.push(['oauth_signature="', hash, '"'].join(''));
   normalizedHeader = 'OAuth ' + normalizedHeaderParts.join(', ');
   
-  console.log(normalizedHeader);
   // 6. Finally return our header
   return(normalizedHeader);
 }

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -1,0 +1,106 @@
+/* 
+TODO:
+- General clean-up
+- Write tests
+- Test support for PLAINTEXT signatures
+- Support for realms
+*/
+
+var querystring = require('querystring'), 
+    crypto      = require('crypto');
+
+// Utility: Generate a random string to use as nonce
+function getNonce(len) {
+  var nonce = [];
+  var chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz";
+  for (var i = 0; i < (len ? len : 32); i++) {
+    var pos = Math.floor(Math.random()*chars.length);
+    nonce.push(chars.substr(pos,1));
+  }
+  return(nonce.join(''));
+}
+
+// Utility: URL encoding is slightly complex in the OAuth spec
+function uriEncode(s) {
+  var s= encodeURIComponent(s);
+  return s.replace(/\!/g, "%21")
+          .replace(/\'/g, "%27")
+          .replace(/\(/g, "%28")
+          .replace(/\)/g, "%29")
+          .replace(/\*/g, "%2A");
+}
+
+// Utility: Mix content of one object into another (1:1 dublicate from restler.js; can be eliminated)
+function mixin(target, source) {
+  Object.keys(source).forEach(function(key) {
+    target[key] = source[key];
+  });
+  
+  return target;
+}
+
+// This function returns a fully signed Authorization header based on 
+// the restler request. Note that the code relies on pre-parsing done
+// by resler beforehand; and notably that `url` is a parsed object, 
+// not a string.
+exports.signature = function(url, options){
+  // Default some options
+  options.oauthSignatureMethod = options.oauthSignatureMethod||"HMAC-SHA1"
+
+  // 1. NORMALIZE URL
+  // Turn protocol into lower case
+  var normalizedURL = [
+                       url.protocol.toLowerCase(), 
+                       '//', url.hostname, 
+                       ((url.protocol==='http:' && url.port==='80') || (url.protocol==='https:' && url.port==='443') ? '' : ':' + url.port),
+                       url.pathname
+                       ].join('');
+
+  // 2. NORMALIZE PARAMS (not sure if this is needed by restler, but good as a general approach)
+  var params = querystring.parse(url.query);
+  if (!options.multipart) mixin(params, querystring.parse(options.data));
+  params['oauth_timestamp'] = Math.round((+(new Date)/1000));
+  params['oauth_nonce'] = getNonce();
+  params['oauth_version'] = '1.0';
+  params['oauth_signature_method'] = options.oauthSignatureMethod;
+  params['oauth_consumer_key'] = options.oauthConsumerKey;
+  if(typeof options.oauthAccessToken != 'undefined' && options.oauthAccessToken != null && options.oauthAccessToken.length>0)
+    params['oauth_token'] = options.oauthAccessToken;
+  // order by parameter name
+  var keys = [];
+  for(var key in params) keys.push(key);
+  keys.sort();
+  // build a normalized querystring
+  var normalizedParts = [];
+  keys.forEach(function(key){
+      normalizedParts.push([uriEncode(key), '=', uriEncode(params[key])].join(''));
+    });
+  normalizedParams = normalizedParts.join('&')
+
+  // 3. Create a base string for signatures
+  var signatureBaseString = [options.method.toUpperCase(), uriEncode(normalizedURL), uriEncode(normalizedParams)].join('&');
+  //console.log(signatureBaseString);
+
+  // 4. And actually sign the string
+  var signatureSecret = [uriEncode(options.oauthConsumerSecret||''), uriEncode(options.oauthAccessTokenSecret||'')].join('&');
+  if (options.oauthSignatureMethod==="HMAC-SHA1") {
+    var hash = uriEncode(crypto.createHmac("sha1", signatureSecret).update(signatureBaseString).digest("base64"));
+  } else {
+    var hash = uriEncode(signatureSecret);
+  }
+
+  // 5. Build the Authentication 
+  // select out the relevant heders, and build yet another string
+  var normalizedHeaderParts = [];
+  keys.forEach(function(key){
+      if(key.match(/^oauth_/) && key!='oauth_callback' && key!='oauth_verifier') {
+        normalizedHeaderParts.push([uriEncode(key), '="', uriEncode(params[key]), '"'].join(''));
+      }
+    });
+  normalizedHeaderParts.push(['oauth_signature="', hash, '"'].join(''));
+  normalizedHeader = 'OAuth ' + normalizedHeaderParts.join(', ');
+  
+  console.log(normalizedHeader);
+  // 6. Finally return our header
+  return(normalizedHeader);
+}

--- a/lib/visualplatform.js
+++ b/lib/visualplatform.js
@@ -29,6 +29,9 @@ as their second and third parameters.
 
 var OAuthAuthentication = require('./authentication');
 var Promise = require("promise");
+var oauth = require('./oauth');
+var url = require('url');
+var querystring = require('querystring');
 
 
 module.exports = Visualplatform = function(domain, key, secret, callback_url){
@@ -48,64 +51,31 @@ module.exports = Visualplatform = function(domain, key, secret, callback_url){
 	    data['raw'] = '1';
 	    access_token = access_token||'';
 	    access_secret = access_secret||'';
-	    
 	    // Set up the request with callbacks
-	    rest.post('http://'+$.serviceDomain+method, {
-	        oauthConsumerKey: $.consumer_key,
-	          oauthConsumerSecret: $.consumer_secret,
-	          oauthAccessToken: access_token,
-	          oauthAccessTokenSecret: access_secret,
-	          data:data
-	          }).on('success', function(res) {            
-		            res = JSON.parse(res);
-		            if(!res.status == 'ok') return reject(res.message);
-		            else return fulfill(res);
-	              }).on('error', function(err) {
-	                err = JSON.parse(err);
-	                return reject(err.message);
-	              }).on('timeout', function(ms) {
-                    return reject('Timeout: ' + ms);
-                  });
+
+	    rest.post('https://'+$.serviceDomain+method, {
+            data:data,
+            headers: {
+              Authorization: oauth.signature(url.parse('https://'+$.serviceDomain+':443'+method+'?'+querystring.stringify(data)), {
+                oauthConsumerKey: $.consumer_key,
+                oauthConsumerSecret: $.consumer_secret,
+                oauthAccessToken: access_token,
+                oauthAccessTokenSecret: access_secret,
+                method: 'POST'
+              })
+            }
+          }).on('success', function(res) {            
+            res = JSON.parse(res);
+            if(!res.status == 'ok') return reject(res.message);
+            else return fulfill(res);
+          }).on('error', function(err) {
+            err = JSON.parse(err);
+            return reject(err.message);
+          }).on('timeout', function(ms) {
+            return reject('Timeout: ' + ms);
+          });
     });
   }
-  
-  $.concatenate = function(methods, access_token, access_secret){
-    return new Promise(function(fulfill, reject) {
-      methods = methods||[];
-      data = data||{};
-      data['format'] = 'json';
-      data['raw'] = '1';
-      access_token = access_token||'';
-      access_secret = access_secret||'';
-      var objectNames = [];
-      var objectCallbacks = {};
-      var i = 0;
-      $.each(methods, function(i,o){
-        var name = o.name||o.method.split('/').slice(2).join('') + '_' + (i++);
-        objectNames.push(name);
-        objectCallbacks[name] = o.callback || function(){};
-        data[name] = o.method + (o.data ? ('?'+$.param(o.data)) : '');
-      });
-      
-      // Set up the request with callbacks
-      rest.post('http://'+$.serviceDomain+'/api/concatenate', {
-        oauthConsumerKey: $.consumer_key,
-        oauthConsumerSecret: $.consumer_secret,
-        oauthAccessToken: access_token,
-        oauthAccessTokenSecret: access_secret,
-        data:data
-      }).on('success', function(res) {            
-        res = JSON.parse(res);
-        if(!res.status == 'ok') return reject(res.message);
-        else return fulfill(res);
-      }).on('error', function(err) {
-        err = JSON.parse(err);
-        return reject(err.message);
-      }).on('timeout', function(ms) {
-        return reject('Timeout: ' + ms);
-      });
-    });    
-  }  
   
   // Map entire Visualplatform API
   var methods = ['/api/analytics/report/event', '/api/analytics/report/play', '/api/analytics/extract/play-details', '/api/analytics/extract/play-totals', '/api/album/create', '/api/album/delete', '/api/album/list', '/api/album/update', '/api/comment/add', '/api/comment/delete', '/api/comment/list', '/api/photo/coordinate/add', '/api/photo/coordinate/delete', '/api/distribution/ios/push-notification', '/api/distribution/ios/register-device', '/api/distribution/ios/unregister-device', '/api/license/list', '/api/live/create', '/api/live/delete', '/api/live/list', '/api/live/update', '/api/live/upload-image', '/api/live/start-recording', '/api/live/stop-recording', '/api/photo/delete', '/api/photo/frame', '/api/photo/get-upload-token', '/api/photo/list', '/api/photo/rate', '/api/photo/redeem-upload-token', '/api/photo/replace', '/api/photo/update', '/api/photo/update-upload-token', '/api/photo/upload', '/api/player/list', '/api/player/settings', '/api/photo/section/create', '/api/photo/section/delete', '/api/photo/section/list', '/api/photo/section/set-thumbnail', '/api/photo/section/update', '/api/session/get-token', '/api/session/redeem-token', '/api/site/get', '/api/photo/subtitle/list', '/api/tag/list', '/api/tag/related', '/api/echo', '/api/user/create', '/api/user/get-login-token', '/api/user/list', '/api/user/redeem-login-token'];

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "promise": "~5.0.0",
-    "restler": "git://github.com/danwrong/restler.git",
+    "restler": "git+https://github.com/danwrong/restler.git",
     "commander": "~2.3.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "promise": "~5.0.0",
-    "restler": "git+https://github.com/danwrong/restler.git",
+    "restler": "~3.1.0",
     "commander": "~2.3.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "promise": "~5.0.0",
-    "restler": "git://github.com/peterdremstrup/restler.git#master",
+    "restler": "git://github.com/danwrong/restler.git",
     "commander": "~2.3.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-23video",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "node-23video is a full implementation of The 23 Video API (or more correctly, The Visualplatform API) for Node.js.",
   "main": "lib/visualplatform.js",
   "scripts": {


### PR DESCRIPTION
Changed from 23 specific Restler-fork (included custom OAuth-signature code) to the one on NPM.
Library should now be more graceful in use with newer node.js setups.

Documentation has also been updated to reflect the real argument options for the CLI version.
